### PR TITLE
Concurrency & parsing improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,17 @@
 /.gradle/
 /.idea/
 /build/
+!src/**/build/
+
+./local.properties
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
+# Cache of project
+.gradletasknamecache

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ allprojects {
         maven {
             url = uri("https://maven.pkg.github.com/atelier-saulx/based-android")
             credentials {
-                username = "SteliosPapamichail"
+                username = System.getenv("BASED_ANDROID_USERNAME")
                 password = System.getenv("BASED_ANDROID_KEY")
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 allprojects {
     group = "com.saulx.based-android-client"
-    version = "0.0.68"
+    version = "0.1.0-beta-1"
 
     repositories {
         mavenLocal()
@@ -8,7 +8,7 @@ allprojects {
         maven {
             url = uri("https://maven.pkg.github.com/atelier-saulx/based-android")
             credentials {
-                username = System.getenv("BASED_ANDROID_USERNAME")
+                username = "SteliosPapamichail"
                 password = System.getenv("BASED_ANDROID_KEY")
             }
         }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -22,7 +22,7 @@ publishing {
         maven {
             url = uri("https://maven.pkg.github.com/atelier-saulx/based-android")
             credentials {
-                username = "SteliosPapamichail"
+                username = System.getenv("BASED_ANDROID_USERNAME")
                 password = System.getenv("BASED_ANDROID_KEY")
             }
         }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    val kotlinVersion = "1.6.0"
+    val kotlinVersion = "1.8.21"
     id("java")
     kotlin("jvm") version kotlinVersion
     id("maven-publish")
@@ -22,7 +22,7 @@ publishing {
         maven {
             url = uri("https://maven.pkg.github.com/atelier-saulx/based-android")
             credentials {
-                username = System.getenv("BASED_ANDROID_USERNAME")
+                username = "SteliosPapamichail"
                 password = System.getenv("BASED_ANDROID_KEY")
             }
         }
@@ -36,7 +36,7 @@ publishing {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
     implementation("net.java.dev.jna:jna:5.13.0")
     implementation("org.slf4j:slf4j-api:1.7.30")
     testImplementation("org.slf4j:slf4j-simple:1.7.30")

--- a/core/src/main/java/com/saulx/based/BasedClient.kt
+++ b/core/src/main/java/com/saulx/based/BasedClient.kt
@@ -1,5 +1,10 @@
+@file:Suppress("LocalVariableName")
+
 package com.saulx.based
 
+import com.saulx.based.exceptions.CallbackException
+import com.saulx.based.extensions.logDataResponse
+import com.saulx.based.extensions.logPayload
 import com.saulx.based.model.AuthState
 import com.saulx.based.model.FileUploadOptions
 import com.sun.jna.CallbackThreadInitializer
@@ -14,6 +19,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -21,8 +27,8 @@ import kotlin.coroutines.suspendCoroutine
 @ExperimentalCoroutinesApi
 class BasedClient(private val enableTLS: Boolean = false) : DisposableHandle {
 
-    private val getMap: HashMap<Int, BasedLibrary.GetCallback> = HashMap()
-    private val functionMap: HashMap<Int, BasedLibrary.GetCallback> = HashMap()
+    private val getMap: ConcurrentHashMap<Int, BasedLibrary.GetCallback> = ConcurrentHashMap()
+    private val functionMap: ConcurrentHashMap<Int, BasedLibrary.GetCallback> = ConcurrentHashMap()
 
     private val clientId = libraryInstance.Based__new_client(enableTLS)
     private val clusterUrl = "production"
@@ -42,11 +48,11 @@ class BasedClient(private val enableTLS: Boolean = false) : DisposableHandle {
         val objState = """{ "token": "$state" }"""
         return withContext(Dispatchers.IO) {
             suspendCoroutine {
-                println("auth: sending $objState")
+                logger.logPayload("auth", objState)
                 val callback =
                     object : BasedLibrary.AuthCallback {
                         override fun invoke(data: String) {
-                            println("auth :: callback data '$data'")
+                            logger.logDataResponse("auth", data)
                             authState = state
                             it.resume(data)
                         }
@@ -67,17 +73,17 @@ class BasedClient(private val enableTLS: Boolean = false) : DisposableHandle {
             var index = 0
             val callback = object : BasedLibrary.GetCallback {
                 override fun invoke(data: String, error: String) {
-                    println("$name :: callback data '$data'. Error '$error'")
                     getMap.remove(index)
                     if (error.isEmpty()) {
                         it.resume(data)
                     } else {
-                        it.resumeWithException(RuntimeException(error))
+                        it.resumeWithException(CallbackException("Error occurred in $name callback: $error"))
                     }
+                    logger.logDataResponse(name, data)
                 }
             }
             Native.setCallbackThreadInitializer(callback, callbackInitializer)
-            println("$name :: sending '$payload'")
+            logger.logPayload(name, payload)
             index = (Native.synchronizedLibrary(libraryInstance) as BasedLibrary).Based__get(
                 clientId,
                 name,
@@ -94,16 +100,17 @@ class BasedClient(private val enableTLS: Boolean = false) : DisposableHandle {
             val callback = object :
                 BasedLibrary.GetCallback {
                 override fun invoke(data: String, error: String) {
-                    println("$name :: callback data '$data'. Error '$error'")
+                    functionMap.remove(index)
                     if (error.isEmpty()) {
                         it.resume(data)
                     } else {
-                        it.resumeWithException(RuntimeException(error))
+                        it.resumeWithException(CallbackException("Error occurred in $name callback: $error"))
                     }
+                    logger.logDataResponse(name, data)
                 }
             }
             Native.setCallbackThreadInitializer(callback, callbackInitializer)
-            println("$name :: sending '$payload'")
+            logger.logPayload(name, payload)
             index = (Native.synchronizedLibrary(libraryInstance) as BasedLibrary).Based__call(
                 clientId,
                 name,
@@ -133,7 +140,7 @@ class BasedClient(private val enableTLS: Boolean = false) : DisposableHandle {
         host: String = "",
         discoverUrl: String = ""
     ) {
-        println("Based__connect with: org:$org, project:$project, env:$env, name:$name, discoverUrl:$discoverUrl, TLS:$enableTLS")
+        logger.debug("Based__connect with: org:$org, project:$project, env:$env, name:$name, discoverUrl:$discoverUrl, TLS:$enableTLS")
         this.connectionInfo = ConnectionInfo(org, project, env)
         libraryInstance.Based__connect(
             clientId,
@@ -152,7 +159,7 @@ class BasedClient(private val enableTLS: Boolean = false) : DisposableHandle {
     fun observe(name: String, payload: String): Flow<String> {
         var callback: BasedLibrary.ObserveCallback
         return callbackFlow {
-            println("$name :: sending '$payload'")
+            logger.logPayload(name, payload)
             callback = object :
                 BasedLibrary.ObserveCallback {
                 override fun invoke(
@@ -164,7 +171,7 @@ class BasedClient(private val enableTLS: Boolean = false) : DisposableHandle {
                     if (error.isEmpty()) {
                         trySend(data)
                     } else {
-                        println("got exception: $error")
+                        logger.error("got exception: $error")
                         throw RuntimeException(error)
                     }
 
@@ -180,8 +187,8 @@ class BasedClient(private val enableTLS: Boolean = false) : DisposableHandle {
         }
     }
 
-    suspend fun file(fileOptions: FileUploadOptions): String? {
-        println("Start creating the file: ${fileOptions.fileName}, $connectionInfo")
+    suspend fun file(fileOptions: FileUploadOptions): String {
+        logger.debug("Start creating the file: {}, {}", fileOptions.fileName, connectionInfo)
         return connectionInfo?.let {
             val serverUrl = libraryInstance.Based__get_service(
                 clientId,
@@ -195,8 +202,10 @@ class BasedClient(private val enableTLS: Boolean = false) : DisposableHandle {
                 html = true
             )
             val targetUrl = "${serverUrl}/upload-file"
-            println("Try to upload the file: $targetUrl")
+            logger.debug("Try to upload the file: $targetUrl")
             FileUploader.upload(fileOptions, targetUrl, authState ?: "")
+        } ?: run {
+            throw IllegalStateException("Connection info is null, cannot upload file.")
         }
     }
 

--- a/core/src/main/java/com/saulx/based/BasedClient.kt
+++ b/core/src/main/java/com/saulx/based/BasedClient.kt
@@ -1,5 +1,3 @@
-@file:Suppress("LocalVariableName")
-
 package com.saulx.based
 
 import com.saulx.based.exceptions.CallbackException
@@ -12,8 +10,6 @@ import com.sun.jna.Native
 import com.sun.jna.NativeLong
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.DisposableHandle
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -24,7 +20,6 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
-@ExperimentalCoroutinesApi
 class BasedClient(private val enableTLS: Boolean = false) : DisposableHandle {
 
     private val getMap: ConcurrentHashMap<Int, BasedLibrary.GetCallback> = ConcurrentHashMap()
@@ -172,7 +167,6 @@ class BasedClient(private val enableTLS: Boolean = false) : DisposableHandle {
                         trySend(data)
                     } else {
                         logger.error("got exception: $error")
-                        throw RuntimeException(error)
                     }
 
                 }
@@ -182,7 +176,6 @@ class BasedClient(private val enableTLS: Boolean = false) : DisposableHandle {
 
             awaitClose {
                 unobserve(observerId)
-                cancel()
             }
         }
     }

--- a/core/src/main/java/com/saulx/based/BasedLibrary.kt
+++ b/core/src/main/java/com/saulx/based/BasedLibrary.kt
@@ -1,3 +1,5 @@
+@file:Suppress("LocalVariableName", "FunctionName")
+
 package com.saulx.based
 
 import com.sun.jna.Callback

--- a/core/src/main/java/com/saulx/based/exceptions/Exceptions.kt
+++ b/core/src/main/java/com/saulx/based/exceptions/Exceptions.kt
@@ -1,0 +1,3 @@
+package com.saulx.based.exceptions
+
+class CallbackException(message: String) : RuntimeException(message)

--- a/core/src/main/java/com/saulx/based/extensions/LoggerExt.kt
+++ b/core/src/main/java/com/saulx/based/extensions/LoggerExt.kt
@@ -1,0 +1,11 @@
+package com.saulx.based.extensions
+
+import org.slf4j.Logger
+
+fun Logger.logPayload(funcName:String, payload:String) {
+    debug("$funcName :: sending $payload")
+}
+
+fun Logger.logDataResponse(funcName: String, data:String) {
+    debug("$funcName :: callback data $data")
+}

--- a/core/src/main/java/com/saulx/based/model/ParseResult.kt
+++ b/core/src/main/java/com/saulx/based/model/ParseResult.kt
@@ -1,0 +1,6 @@
+package com.saulx.based.model
+
+sealed class ParseResult<out T> {
+    data class Success<T>(val data: T) : ParseResult<T>()
+    data class Failure(val error: Throwable, val payload: String) : ParseResult<Nothing>()
+}

--- a/core/src/test/kotlin/com/saulx/based/Main.kt
+++ b/core/src/test/kotlin/com/saulx/based/Main.kt
@@ -31,11 +31,11 @@ class CoreTest {
 
         println("file upload test")
         runBlocking {
-            client.get("{ \"\$id\": \"root\", \"children\": true }")
+            client.get("{ \"\$id\": \"root\", \"children\": true }", "")
         }
         val now = System.currentTimeMillis()
         runBlocking {
-            val url = client.file(FileFileUploadOptions(mimeType = "image/png", file = File("src/test/resources/sdkgeneratieflow.png")))
+            val url = client.file(FileFileUploadOptions(payload = "", file = File("")))
             val end = System.currentTimeMillis()
             println("service url $url in ${end - now}ms")
         }

--- a/gson/build.gradle.kts
+++ b/gson/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    val kotlinVersion = "1.6.0"
+    val kotlinVersion = "1.8.21"
     id("java")
     kotlin("jvm") version kotlinVersion
     id("maven-publish")
@@ -24,7 +24,7 @@ publishing {
         maven {
             url = uri("https://maven.pkg.github.com/atelier-saulx/based-android")
             credentials {
-                username = System.getenv("BASED_ANDROID_USERNAME")
+                username = "SteliosPapamichail"
                 password = System.getenv("BASED_ANDROID_KEY")
             }
         }
@@ -38,8 +38,8 @@ publishing {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1")
-    implementation("org.jetbrains.kotlin:kotlin-reflect:1.5.21")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:1.9.0")
 
     implementation(project(":core"))
 

--- a/gson/build.gradle.kts
+++ b/gson/build.gradle.kts
@@ -24,7 +24,7 @@ publishing {
         maven {
             url = uri("https://maven.pkg.github.com/atelier-saulx/based-android")
             credentials {
-                username = "SteliosPapamichail"
+                username = System.getenv("BASED_ANDROID_USERNAME")
                 password = System.getenv("BASED_ANDROID_KEY")
             }
         }

--- a/gson/src/main/kotlin/com/saulx/based/client/gson/BasedClientGsonExtensions.kt
+++ b/gson/src/main/kotlin/com/saulx/based/client/gson/BasedClientGsonExtensions.kt
@@ -3,10 +3,11 @@ package com.saulx.based.client.gson
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonElement
+import com.saulx.based.BasedClient
+import com.saulx.based.model.ParseResult
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import com.saulx.based.BasedClient
 
 private var gson = GsonBuilder().create()
 
@@ -17,7 +18,8 @@ fun BasedClient.useGson(gsonInstance: Gson) {
 
 @ExperimentalCoroutinesApi
 suspend fun BasedClient.get(name: String, payload: JsonElement?): JsonElement {
-    return gson.fromJson(this.get(name, payload?.let { gson.toJson(payload) } ?: ""), JsonElement::class.java)
+    return gson.fromJson(this.get(name, payload?.let { gson.toJson(payload) } ?: ""),
+        JsonElement::class.java)
 }
 
 @ExperimentalCoroutinesApi
@@ -27,22 +29,42 @@ suspend fun <T> BasedClient.get(name: String, payload: Any?, returnType: Class<T
 
 @ExperimentalCoroutinesApi
 suspend fun BasedClient.function(name: String, payload: JsonElement?): JsonElement {
-    return gson.fromJson(this.function(name, payload?.let { gson.toJson(payload) } ?: ""), JsonElement::class.java)
+    return gson.fromJson(this.function(name, payload?.let { gson.toJson(payload) } ?: ""),
+        JsonElement::class.java)
 }
 
 @ExperimentalCoroutinesApi
 suspend fun <T> BasedClient.function(name: String, payload: Any?, returnType: Class<T>): T {
-    return gson.fromJson(this.function(name, payload?.let { gson.toJson(payload) } ?: ""), returnType)
+    return gson.fromJson(this.function(name, payload?.let { gson.toJson(payload) } ?: ""),
+        returnType)
 }
 
 @ExperimentalCoroutinesApi
-fun BasedClient.observe(name: String, payload: JsonElement?): Flow<JsonElement> {
+fun BasedClient.observe(name: String, payload: JsonElement?): Flow<ParseResult<JsonElement>> {
     return this.observe(name, payload?.let { gson.toJson(payload) } ?: "")
-        .map { gson.fromJson(it, JsonElement::class.java) }
+        .map { json ->
+            try {
+                ParseResult.Success(gson.fromJson(json, JsonElement::class.java))
+            } catch (e: Exception) {
+                ParseResult.Failure(e, json)
+            }
+        }
 }
 
 @ExperimentalCoroutinesApi
-fun <T> BasedClient.observe(name: String, payload: Any?, returnType: Class<T>): Flow<T> {
-    return this.observe(name, payload?.let { gson.toJson(payload) } ?: "")
-        .map { gson.fromJson(it, returnType) }
+fun <T> BasedClient.observe(
+    name: String,
+    payload: Any?,
+    returnType: Class<T>
+): Flow<ParseResult<T>> {
+    return this.observe(name, payload?.let {
+        gson.toJson(payload)
+    } ?: "")
+        .map { json ->
+            try {
+                ParseResult.Success(gson.fromJson(json, returnType))
+            } catch (e: Exception) {
+                ParseResult.Failure(e, json)
+            }
+        }
 }

--- a/gson/src/main/kotlin/com/saulx/based/client/gson/BasedClientGsonExtensions.kt
+++ b/gson/src/main/kotlin/com/saulx/based/client/gson/BasedClientGsonExtensions.kt
@@ -7,7 +7,9 @@ import com.saulx.based.BasedClient
 import com.saulx.based.model.ParseResult
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
 
 private var gson = GsonBuilder().create()
 
@@ -46,6 +48,7 @@ fun BasedClient.observe(name: String, payload: JsonElement?): Flow<ParseResult<J
             try {
                 ParseResult.Success(gson.fromJson(json, JsonElement::class.java))
             } catch (e: Exception) {
+                e.printStackTrace()
                 ParseResult.Failure(e, json)
             }
         }
@@ -64,6 +67,7 @@ fun <T> BasedClient.observe(
             try {
                 ParseResult.Success(gson.fromJson(json, returnType))
             } catch (e: Exception) {
+                e.printStackTrace()
                 ParseResult.Failure(e, json)
             }
         }

--- a/local.properties
+++ b/local.properties
@@ -4,6 +4,6 @@
 # Location of the SDK. This is only used by Gradle.
 # For customization when using a Version Control System, please read the
 # header note.
-#Mon Feb 13 14:35:35 MSK 2023
-sdk.dir=C\:\\Users\\itsqo\\AppData\\Local\\Android\\Sdk
+#Wed Feb 26 12:23:24 CET 2025
 ndk.dir=C\:\\Users\\itsqo\\AppData\\Local\\Android\\Sdk\\ndk\\21.0.6113669\\platforms
+sdk.dir=/Users/spapamairhub/Library/Android/sdk


### PR DESCRIPTION
This PR aims to improve and fix potential concurrency issues in the `:core` module, as well as improve the flow parsing logic in the `:gson` module. Below follows an outline of the changes:

- Improved logging by using the actual SLF4J logger and proper log levels instead of `println()` calls
- Used a `ConcurrentHashMap` instead of a normal hashmap to avoid concurrency issues when altering the maps contents. See [ConcurrentHashMap](https://developer.android.com/reference/kotlin/java/util/concurrent/ConcurrentHashMap).
- Added support for removing callbacks from the `functionMap` in the `function()` method, similar to the `getMap`
- Added better error reporting via exceptions
- Implemented a `sealed class ParseResult<out T>` to wrap emitted values in the `observe()` overloaded methods. This would allow consumers of this flow to decide how they want to handle faulty values as well as ease error logging. Previously, a single faulty value could lead to losing all the emissions without the ability to know which value(s) was the faulty one.